### PR TITLE
Partially reset contents when composition is resolved

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -552,20 +552,18 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
   /**
    * @todo fill out docs
    */
-  restoreEditorBlocks = (
-    targetBlockKeys: string[],
+  restoreEditorBlock = (
+    blockKey: string,
     scrollPosition?: DraftScrollPosition,
   ): void => {
     let {blockKeyRestoreMap} = this.state;
 
-    targetBlockKeys.forEach(blockKey => {
-      blockKeyRestoreMap = blockKeyRestoreMap.set(
-        blockKey,
-        blockKeyRestoreMap.has(blockKey)
-          ? blockKeyRestoreMap.get(blockKey) + 1
-          : 1,
-      );
-    });
+    blockKeyRestoreMap = blockKeyRestoreMap.set(
+      blockKey,
+      blockKeyRestoreMap.has(blockKey)
+        ? blockKeyRestoreMap.get(blockKey) + 1
+        : 1,
+    );
 
     this.setState({blockKeyRestoreMap}, () => {
       this.focus(scrollPosition);

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -256,6 +256,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
     this.state = {
       // See `restoreEditorDOM()`.
       contentsKey: 0,
+      // See `restoreEditorBlockDOM()`.
       blockKeyRestoreMap: new Map({}),
     };
   }
@@ -550,9 +551,13 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
   };
 
   /**
-   * @todo fill out docs
+   * Used via `this.restoreEditorBlockDOM()`.
+   *
+   * Force a complete re-render of the DraftEditorBlock in DraftEditorContents
+   * specified by its blockKey. This is used when restoration of editor block DOM
+   * is necessary but the effect of change is scoped in a block.
    */
-  restoreEditorBlock = (
+  restoreEditorBlockDOM = (
     blockKey: string,
     scrollPosition?: DraftScrollPosition,
   ): void => {

--- a/src/component/contents/DraftEditorContents-core.react.js
+++ b/src/component/contents/DraftEditorContents-core.react.js
@@ -18,6 +18,7 @@ import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type EditorState from 'EditorState';
 import type {BidiDirection} from 'UnicodeBidiDirection';
+import type {Map} from 'immutable';
 
 const DraftEditorBlock = require('DraftEditorBlock.react');
 const DraftOffsetKey = require('DraftOffsetKey');
@@ -36,6 +37,7 @@ type Props = {
   editorKey?: string,
   editorState: EditorState,
   textDirectionality?: BidiDirection,
+  blockKeyRestoreMap: Map,
 };
 
 /**
@@ -87,6 +89,11 @@ class DraftEditorContents extends React.Component<Props> {
       return true;
     }
 
+    // Block level restoration should update the key of target EditorBlocks
+    if (this.props.blockKeyRestoreMap !== nextProps.blockKeyRestoreMap) {
+      return true;
+    }
+
     const didHaveFocus = prevEditorState.getSelection().getHasFocus();
     const nowHasFocus = nextEditorState.getSelection().getHasFocus();
 
@@ -132,6 +139,7 @@ class DraftEditorContents extends React.Component<Props> {
       editorState,
       editorKey,
       textDirectionality,
+      blockKeyRestoreMap,
     } = this.props;
 
     const content = editorState.getCurrentContent();
@@ -173,7 +181,7 @@ class DraftEditorContents extends React.Component<Props> {
         decorator,
         direction,
         forceSelection,
-        key,
+        key: `${key}-${blockKeyRestoreMap.get(key) || '0'}`,
         offsetKey,
         selection,
         tree: editorState.getBlockTree(key),

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -186,9 +186,17 @@ const DraftEditorCompositionHandler = {
       ) {
         return;
       }
+
+      const newEditorState = mustReset
+        ? EditorState.set(editorState, {
+            nativelyRenderedContent: null,
+            forceSelection: true,
+          })
+        : editorState;
+
       editor.update(
         EditorState.push(
-          editorState,
+          newEditorState,
           // If characters have been composed, re-rendering with the update
           // is sufficient to reset the editor.
           DraftModifier.replaceText(

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -160,7 +160,7 @@ const DraftEditorCompositionHandler = {
       entityKey !== null;
 
     if (mustReset) {
-      const blockKeys = [...contentState.getBlockMap().keys()];
+      const blockKeys = Array.from(contentState.getBlockMap().keys());
       const anchorKeyIndex = blockKeys.indexOf(selectionState.getAnchorKey());
       const focusKeyIndex = blockKeys.indexOf(selectionState.getFocusKey());
 

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -159,7 +159,8 @@ const DraftEditorCompositionHandler = {
       entityKey !== null;
 
     if (mustReset) {
-      editor.restoreEditorDOM();
+      // Update the block which currently have focus
+      editor.restoreEditorBlocks([editorState.getSelection().getFocusKey()]);
     }
 
     editor.exitCurrentMode();

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -163,8 +163,6 @@ const DraftEditorCompositionHandler = {
       const anchorKey = selectionState.getAnchorKey();
       const focusKey = selectionState.getFocusKey();
 
-      console.log({anchorKey, focusKey});
-
       if (anchorKey !== focusKey) {
         editor.restoreEditorDOM();
       } else {

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -174,6 +174,8 @@ const DraftEditorCompositionHandler = {
           ? blockKeys.slice(anchorKeyIndex, focusKeyIndex + 1)
           : blockKeys.slice(focusKeyIndex, anchorKeyIndex + 1);
 
+      console.log({ blockKeys, targetBlocks, anchorKeyIndex, focusKeyIndex });
+
       // Update the block which currently have focus
       editor.restoreEditorBlocks(targetBlocks);
     }

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -164,7 +164,7 @@ const DraftEditorCompositionHandler = {
 
       if (anchorKey === focusKey) {
         // Update the block which currently have focus
-        editor.restoreEditorBlock(focusKey);
+        editor.restoreEditorBlockDOM(focusKey);
       } else {
         // If selection contains 2 or more blocks, reset the whole contents
         editor.restoreEditorDOM();
@@ -188,16 +188,9 @@ const DraftEditorCompositionHandler = {
         return;
       }
 
-      const newEditorState = mustReset
-        ? EditorState.set(editorState, {
-            nativelyRenderedContent: null,
-            forceSelection: true,
-          })
-        : editorState;
-
       editor.update(
         EditorState.push(
-          newEditorState,
+          editorState,
           // If characters have been composed, re-rendering with the update
           // is sufficient to reset the editor.
           DraftModifier.replaceText(

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -162,11 +162,12 @@ const DraftEditorCompositionHandler = {
       const anchorKey = selectionState.getAnchorKey();
       const focusKey = selectionState.getFocusKey();
 
-      if (anchorKey !== focusKey) {
-        editor.restoreEditorDOM();
-      } else {
+      if (anchorKey === focusKey) {
         // Update the block which currently have focus
         editor.restoreEditorBlock(focusKey);
+      } else {
+        // If selection contains 2 or more blocks, reset the whole contents
+        editor.restoreEditorDOM();
       }
     }
 

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -21,7 +21,6 @@ const Keys = require('Keys');
 
 const getEntityKeyForSelection = require('getEntityKeyForSelection');
 const gkx = require('gkx');
-const invariant = require('invariant');
 const isEventHandled = require('isEventHandled');
 const isSelectionAtLeafStart = require('isSelectionAtLeafStart');
 

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -164,8 +164,10 @@ const DraftEditorCompositionHandler = {
       const anchorKeyIndex = blockKeys.indexOf(selectionState.getAnchorKey());
       const focusKeyIndex = blockKeys.indexOf(selectionState.getFocusKey());
 
+      console.log({ blockKeys, targetBlocks, anchorKeyIndex, focusKeyIndex });
+
       invariant(
-        anchorKeyIndex === -1 || focusKeyIndex === -1,
+        anchorKeyIndex !== -1 && focusKeyIndex !== -1,
         'Content does not contain blocks in selection',
       );
 
@@ -174,7 +176,6 @@ const DraftEditorCompositionHandler = {
           ? blockKeys.slice(anchorKeyIndex, focusKeyIndex + 1)
           : blockKeys.slice(focusKeyIndex, anchorKeyIndex + 1);
 
-      console.log({ blockKeys, targetBlocks, anchorKeyIndex, focusKeyIndex });
 
       // Update the block which currently have focus
       editor.restoreEditorBlocks(targetBlocks);

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -160,25 +160,17 @@ const DraftEditorCompositionHandler = {
       entityKey !== null;
 
     if (mustReset) {
-      const blockKeys = Array.from(contentState.getBlockMap().keys());
-      const anchorKeyIndex = blockKeys.indexOf(selectionState.getAnchorKey());
-      const focusKeyIndex = blockKeys.indexOf(selectionState.getFocusKey());
+      const anchorKey = selectionState.getAnchorKey();
+      const focusKey = selectionState.getFocusKey();
 
-      console.log({ blockKeys, targetBlocks, anchorKeyIndex, focusKeyIndex });
+      console.log({anchorKey, focusKey});
 
-      invariant(
-        anchorKeyIndex !== -1 && focusKeyIndex !== -1,
-        'Content does not contain blocks in selection',
-      );
-
-      const targetBlocks =
-        anchorKeyIndex < focusKeyIndex
-          ? blockKeys.slice(anchorKeyIndex, focusKeyIndex + 1)
-          : blockKeys.slice(focusKeyIndex, anchorKeyIndex + 1);
-
-
-      // Update the block which currently have focus
-      editor.restoreEditorBlocks(targetBlocks);
+      if (anchorKey !== focusKey) {
+        editor.restoreEditorDOM();
+      } else {
+        // Update the block which currently have focus
+        editor.restoreEditorBlock(focusKey);
+      }
     }
 
     editor.exitCurrentMode();


### PR DESCRIPTION
*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to Draft.js!

-

**Summary**

Editor restoration before resolving composition is necessary, but the whole restoration of editor contents DOM might cause flash of embedded contents, like iframes or images.
Every text composition at the beginning of blocks would cause flash of editor, and it makes experience so worse.

After this change, if the change is scoped within a block, only the DOM of the block would reset.

**Test Plan**

// TODO